### PR TITLE
Fix handling of file fields

### DIFF
--- a/CRM/Contract/Handler/Contract.php
+++ b/CRM/Contract/Handler/Contract.php
@@ -148,6 +148,7 @@ class CRM_Contract_Handler_Contract{
 
     // Setting skip_handler to true  avoids us 'handling the already handled' call
     $params = $this->convertCustomIds($this->params);
+    $params = $this->convertFileFields($params);
     $params['skip_handler'] = true;
     civicrm_api3('Membership', 'create', $params);
     $this->setEndState($params['id']);
@@ -251,6 +252,7 @@ class CRM_Contract_Handler_Contract{
       }
     }
     $params = $this->convertCustomIds($params);
+    $params = $this->convertFileFields($params);
 
     $params['skip_handler'] = true;
 
@@ -491,6 +493,22 @@ class CRM_Contract_Handler_Contract{
       if(strpos($key, '.')){
         unset($params[$key]);
         $params[CRM_Contract_Utils::getCustomFieldId($key)] = $param;
+      }
+    }
+    return $params;
+  }
+
+  /**
+   * Convert file fields passed as array to just the numeric file ID
+   *
+   * @param $params
+   *
+   * @return mixed
+   */
+  private function convertFileFields($params){
+    foreach($params as $key => $param) {
+      if (is_array($param) && !empty($param['fid'])) {
+        $params[$key] = $param['fid'];
       }
     }
     return $params;

--- a/CRM/Contract/Handler/Contract.php
+++ b/CRM/Contract/Handler/Contract.php
@@ -507,8 +507,13 @@ class CRM_Contract_Handler_Contract{
    */
   private function convertFileFields($params){
     foreach($params as $key => $param) {
-      if (is_array($param) && !empty($param['fid'])) {
-        $params[$key] = $param['fid'];
+      if (is_array($param)) {
+        if (!empty($param['fid'])) {
+          $params[$key] = $param['fid'];
+        }
+        else if (!empty($param['id']) && array_key_exists('data', $param)) {
+          unset($params[$key]);
+        }
       }
     }
     return $params;


### PR DESCRIPTION
When memberships with file fields are updated, the contract handler tries to set the custom field to an array, while the API expects a file ID instead.

GP-2156