### PR TITLE
Fix a JavaScript error in dialogs after membership tab was opened

### DIFF
--- a/templates/CRM/Member/Page/Tab.js
+++ b/templates/CRM/Member/Page/Tab.js
@@ -118,9 +118,10 @@ CRM.$(function($) {
 
     $(document).on( 'crmPopupFormSuccess', '.action-item', function(){
       var elementId = $(this).parents('.crm-membership').attr('id');
-      var membershipId = elementId.substr(elementId.indexOf("_") + 1);
-      // console.log(membershipId);
-      // TODO: anything to do here?
+      if (elementId) {
+        var membershipId = elementId.substr(elementId.indexOf("_") + 1);
+        // TODO: anything to do here?
+      }
     });
 
     CRM.vars['de.systopia.contract'].listenersLoaded = true;


### PR DESCRIPTION
This fixes a JavaScript error that can be triggered by first opening the membership tab and then performing any other action on the contact that might involve a dialog being closed.